### PR TITLE
fix: Show Zeebe-Play version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,37 @@
         </executions>
       </plugin>
 
+      <!--
+        Write the current version into a file. This file is read to show the current version of the
+        application in the UI. The common way with the manifest file doesn't work because of Jib.
+       -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>copy-version-file</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/resources/</directory>
+                  <includes>
+                    <include>version.txt</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
   </build>

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/StatusResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/StatusResource.kt
@@ -12,7 +12,7 @@ class StatusResource(
     private val zeebeClient: ZeebeClient
 ) {
 
-    private val zeebePlayVersion: String = javaClass.`package`.implementationVersion ?: "dev"
+    private val zeebePlayVersion: String = readZeebePlayVersion()
 
     @RequestMapping(method = [RequestMethod.GET])
     fun getStatus(): StatusDto {
@@ -50,6 +50,12 @@ class StatusResource(
             )
         }
 
+    }
+
+    private fun readZeebePlayVersion(): String {
+        return javaClass.getResource("/version.txt")
+                ?.let { String(it.readBytes()) }
+                ?: "?"
     }
 
     data class StatusDto(

--- a/src/main/resources/version.txt
+++ b/src/main/resources/version.txt
@@ -1,0 +1,1 @@
+${project.version}


### PR DESCRIPTION
## Description

Currently, the Zeebe-Play version is always "dev" if it is used as a Docker image. The common way with the manifest file (generated by the JAR plugin) doesn't work because Jib doesn't use the JAR but the class files directly.

Solve this issue by using a special file to store the version on building the artifact. By using the JAR, it should fix the issue that the Zeebe-Play version is not shown.

## Related issues
